### PR TITLE
add upgrade lean workflow to CI

### DIFF
--- a/.github/workflows/upgrade_lean.yml
+++ b/.github/workflows/upgrade_lean.yml
@@ -1,0 +1,18 @@
+on:
+  schedule:
+    - cron: '0 2 * * *' # once a day at 2am UTC
+
+jobs:
+  upgrade_lean:
+    runs-on: ubuntu-latest
+    name: Bump Lean and dependency versions
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v2
+      - name: upgrade Lean and dependencies
+        uses: leanprover-contrib/lean-upgrade-action@master
+        with:
+          repo: ${{ github.repository }}
+          access-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: update version branches
+        uses: leanprover-contrib/update-versions-action@master


### PR DESCRIPTION
I noticed you're not using the scheduled upgrade action -- I think this would be a good idea!

Once a day (or on any schedule you'd prefer) this will run `leanproject up`, upgrading to the most recent mathlib, and try to build the project. If it succeeds, it will push the upgrade to master. If it fails, it will open an issue that indicates which mathlib commits might have caused the breakage.

I'm not 100% sure how this will interact with the dependency on `lean-gptf`'s master branch instead of a fixed commit. But I don't think it's dangerous to find out.